### PR TITLE
Cull children since the script does not mount parents

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -37,6 +37,12 @@ class ChoosePartition:
         r = subprocess.check_output(['lsblk', '--all', '--json', '-O'])
         self.blkinfo = json.loads(r)
         partn = 0
+        # filter for devices with children, none other are used by this script
+        # (this is not entirely correct, but goes beyond these lines)
+        self.blkinfo['blockdevices'] = [
+            bd
+            for bd in self.blkinfo['blockdevices']
+                if 'children' in bd]
         for bd in self.blkinfo['blockdevices']:
             if 'children' not in bd:
                 continue


### PR DESCRIPTION
I don't thing this is entirely correct but I have no example at hand.
You should be able to create a filesystem on e.g. /dev/sde directly without
creating a partition /dev/sde1 first. So, technically this "parent" without
"children" should be mountable.

Since the script does not consider this. This commit filters for
elements/"parents" without "children".

For most cases this will keep the height of the output smaller not to run into a
curses crash. Not ideal and the curses crashes should get looked at, but for now
this will do to reduce crashes with small windows and large amount or block
devices – thanks snap.

Might reduce troubles from #2 