### PR TITLE
Fix JSON decode error.

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -35,7 +35,8 @@ class ChoosePartition:
 
     def _read_partitions(self):
         r = subprocess.check_output(['lsblk', '--all', '--json', '-O'])
-        self.blkinfo = json.loads(r)
+        r = r.decode().replace('0B,', '\"0B\",')
+        self.blkinfo = json.loads(r.encode())
         partn = 0
         for bd in self.blkinfo['blockdevices']:
             if 'children' not in bd:


### PR DESCRIPTION
Related to #4.

The JSON output from lsblk seems to have some issues that interfere with the `json.loads()` function. Specifically, the value 0B, which is expected to be a string.

By doing a direct replace on the lsblk output for `0B` on `menu.py`, the JSON is parsed and the menu appears.