### PR TITLE
use relative path for calling menu.py & clone to ~/.config/ranger/plugins instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,17 @@ This script draws menu to mount and unmount partitions using udisksctl and ncurs
 - lsblk 2.3 or newer
 
 # How to install
-Firstly you need to clone this repo to ranger config directory
+Firstly you need to clone this repo to the plugins directory of ranger
 
 ```Bash
-cd ~/.config/ranger
+cd ~/.config/ranger/plugins
 git clone https://github.com/SL-RU/ranger_udisk_menu
 ```
 
 Then you need to add to `~/.config/ranger/commands.py` line: 
 
 ```Python3
-from ranger_udisk_menu.mounter import mount
+from plugins.ranger_udisk_menu.mounter import mount
 ```
 
 Thats all

--- a/mounter.py
+++ b/mounter.py
@@ -20,8 +20,7 @@ class mount(Command):
         """ Show menu to mount and unmount """
         (f, p) = tempfile.mkstemp()
         os.close(f)
-        self.fm.execute_console(
-            f"shell python3 ~/.config/ranger/ranger_udisk_menu/menu.py {p}")
+        self.fm.execute_console(f"shell python3 {os.getcwd()}/menu.py {p}")
         with open(p, 'r') as f:
             d = f.readline()
             if os.path.exists(d):


### PR DESCRIPTION
Hi I found that `menu.py` is called directly via absolute path in the code. This would fail if the repo is cloned into other directories.

Also, I recommend to clone into `~/.config/ranger/plugins`.